### PR TITLE
Fix: the static prerendering failed on .NET 7

### DIFF
--- a/SD.WEB/wwwroot/appsettings.Prerendering.json
+++ b/SD.WEB/wwwroot/appsettings.Prerendering.json
@@ -1,0 +1,5 @@
+{
+  "StaticWebAppsAuthentication": {
+    "AuthenticationDataUrl": "/sample-data/nobody.json"
+  }
+}

--- a/SD.WEB/wwwroot/sample-data/nobody.json
+++ b/SD.WEB/wwwroot/sample-data/nobody.json
@@ -1,0 +1,3 @@
+﻿{
+  "clientPrincipal": null
+}


### PR DESCRIPTION
Emulate an unsigned-in state during pre-rendering to avoid the pre-rendering process failing.

The hosting environment name will be "Prerendering" during pre-rendering, so the "appsettings.Prerendering.json" will be loaded to the app, and that custom configuration will make the Azure Static Web  App Auth library to fetch an authentication state from the "/sample-data/nobody.json", and that "nobody.js" will return information of an unsigned-in user.